### PR TITLE
fix docker compose image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - 8601:8601
     volumes:
-      - /home/jorge/scratch-elimu:/app
+      - ./:/app
     working_dir: /app/scratch-gui
     command: >
       sh -c "npm install --force && 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
     ports:
       - 8601:8601
     volumes:
-      - ./:/app
+      - /home/jorge/scratch-elimu:/app
     working_dir: /app/scratch-gui
     command: >
       sh -c "npm install --force && 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -14,7 +14,6 @@ services:
       - ./:/app
     working_dir: /app/scratch-gui
     command: >
-      sh -c "npm install --force && 
-             npm start"
+      sh -c "npm install --force"
     profiles:
       - scratch_gui


### PR DESCRIPTION
Boa noite, senhorito, tudo bem?

Estou fazendo uma pequena contribuição na imagem do docker referente ao projeto scratch. Dessa forma não será mais necessário introduzir o caminho do diretório de forma fixa. Para funcionamento do projeto será necessário apenas clonar o repositório e executar o comando abaixo:

`docker-compose --profile scratch_gui up`

Desde já, parabéns pelo projeto!